### PR TITLE
Allow non-www site

### DIFF
--- a/betterlet.user.js
+++ b/betterlet.user.js
@@ -5,6 +5,7 @@
 // @description  LowEndTalk userscript
 // @author       jmg.caguicla
 // @match        https://www.lowendtalk.com/*
+// @match        https://lowendtalk.com/*
 // @grant        GM_setValue
 // @grant        GM_getValue
 // @grant        GM_getResourceText


### PR DESCRIPTION
I've had this installed since march but only realized it wasn't enabled because I use 'lowendtalk.com' while the script only runs on 'www.lowendtalk.com'